### PR TITLE
Add docker file for dev environment

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -7,6 +7,6 @@ WORKDIR $APPLICATION_ROOT
 COPY Pipfile $APPLICATION_ROOT/Pipfile
 COPY Pipfile.lock $APPLICATION_ROOT/Pipfile.lock
 RUN pip install pipenv
-RUN pipenv install --system --ignore-pipfile
+RUN pipenv install --dev --system
 
 ADD . $APPLICATION_ROOT

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,12 @@
+FROM python:3.7.2
+
+ENV APPLICATION_ROOT /app
+RUN mkdir $APPLICATION_ROOT
+WORKDIR $APPLICATION_ROOT
+
+COPY Pipfile $APPLICATION_ROOT/Pipfile
+COPY Pipfile.lock $APPLICATION_ROOT/Pipfile.lock
+RUN pip install pipenv
+RUN pipenv install --system --ignore-pipfile
+
+ADD . $APPLICATION_ROOT


### PR DESCRIPTION
Change of pull request:
- Add python docker file for dev environment by you can use 
```
docker build -t demo-dev -f Dockerfile.dev .
```
- then you can see  the result of image  size by `docker images`

```
REPOSITORY           TAG                    IMAGE ID               CREATED             SIZE
demo-dev           latest                d59fce0d3e3f        11 hours ago        994MB
```